### PR TITLE
Enable All devices access to allow controller support to work

### DIFF
--- a/net.sourceforge.quakespasm.Quakespasm.yml
+++ b/net.sourceforge.quakespasm.Quakespasm.yml
@@ -7,6 +7,8 @@ command: quakespasm.sh
 finish-args:
   # hardware 3D
   - --device=dri
+  # controller support
+  - --device=all
   # X11 + XShm access
   - --share=ipc
   - --socket=x11

--- a/net.sourceforge.quakespasm.Quakespasm.yml
+++ b/net.sourceforge.quakespasm.Quakespasm.yml
@@ -5,8 +5,6 @@ sdk: org.freedesktop.Sdk
 command: quakespasm.sh
 
 finish-args:
-  # hardware 3D
-  - --device=dri
   # controller support
   - --device=all
   # X11 + XShm access


### PR DESCRIPTION
Currently controller support is broken in the flatpak as it cannot access the device. This fix allows controllers to work.